### PR TITLE
Fix laravel 6 incompatibility

### DIFF
--- a/src/ChatkitFactory.php
+++ b/src/ChatkitFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Chatkit\Laravel;
 
 use Chatkit\Chatkit;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
 /**
@@ -53,7 +54,7 @@ class ChatkitFactory
             }
         }
 
-        return array_only($config, $this->configKeys);
+        return Arr::only($config, $this->configKeys);
     }
 
     /**


### PR DESCRIPTION
Laravel 6 does not have array_only helper.
The static method \Illuminate\Support\Arr::only should be used instead.